### PR TITLE
Remove custom value for service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout

### DIFF
--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -74,7 +74,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
 spec:
   ports:
     - port: 443

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -74,7 +74,6 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
 spec:
   ports:
     - port: 443


### PR DESCRIPTION
Remove default `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"` seconds from nodejs ELB service templates

It's probably a good idea to start with the default of 60 seconds