### PR TITLE
Use named ports

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -30,7 +30,8 @@ spec:
           image: {{ project_repo }}:production
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -39,7 +40,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -49,11 +50,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -110,15 +113,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -30,7 +30,8 @@ spec:
           image: {{ project_repo }}:staging
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -39,7 +40,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -49,11 +50,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -110,15 +113,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: NODE_ENV
               value: production
             - name: TRACE_AGENT_HOSTNAME
@@ -34,7 +36,8 @@ spec:
           image: {{ project_repo }}:production
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -43,7 +46,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -53,11 +56,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -114,15 +119,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: NODE_ENV
               value: production
             - name: TRACE_AGENT_HOSTNAME
@@ -34,7 +36,8 @@ spec:
           image: {{ project_repo }}:staging
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -43,7 +46,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -53,11 +56,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -114,15 +119,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -40,7 +42,8 @@ spec:
           image: {{ project_repo }}:production
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -49,7 +52,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -59,11 +62,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -120,15 +125,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -40,7 +42,8 @@ spec:
           image: {{ project_repo }}:staging
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -49,7 +52,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -59,11 +62,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -120,15 +125,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/rails-unicorn/hokusai/production.yml.j2
+++ b/rails-unicorn/hokusai/production.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -40,7 +42,8 @@ spec:
           image: {{ project_repo }}:production
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -49,7 +52,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -59,11 +62,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -120,15 +125,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-

--- a/rails-unicorn/hokusai/staging.yml.j2
+++ b/rails-unicorn/hokusai/staging.yml.j2
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
+            - name: PORT
+              value: "8080"
             - name: RAILS_ENV
               value: production
             - name: RAILS_SERVE_STATIC_FILES
@@ -40,7 +42,8 @@ spec:
           image: {{ project_repo }}:staging
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - name: {{ project_name }}-http
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -49,7 +52,7 @@ spec:
               memory: 500Mi
           readinessProbe:
             httpGet:
-              port: 8080
+              port: {{ project_name }}-http
               path: /health/ping
               httpHeaders:
                 - name: X-Forwarded-Proto
@@ -59,11 +62,13 @@ spec:
         - name: {{ project_name }}-nginx
           image: artsy/docker-nginx:1.14.2
           ports:
-            - containerPort: 80
-            - containerPort: 443
+            - name: nginx-http
+              containerPort: 80
+            - name: nginx-https
+              containerPort: 443
           readinessProbe:
             tcpSocket:
-              port: 80
+              port: nginx-http
             initialDelaySeconds: 5
             periodSeconds: 15
             timeoutSeconds: 10
@@ -120,15 +125,14 @@ spec:
     - port: 80
       protocol: TCP
       name: http
-      targetPort: 80
+      targetPort: nginx-http
     - port: 443
       protocol: TCP
       name: https
-      targetPort: 443
+      targetPort: nginx-https
   selector:
     app: {{ project_name }}
     layer: application
     component: web
   sessionAffinity: None
   type: LoadBalancer
-


### PR DESCRIPTION
Updates examples to use named ports, which allows for graceful port changes in the future. 

- Ensures that PORT is set to '8080' in env
- Names port for web container and uses var for health check
- Names ports for NGINX and uses vars for Service blob ports