### PR TITLE
Don't ignore .rspec file when building Docker images

### DIFF
--- a/rails-puma/.dockerignore.j2
+++ b/rails-puma/.dockerignore.j2
@@ -16,7 +16,6 @@ README.md
 .env.sample
 *.rbc
 capybara-*.html
-.rspec
 log
 tmp
 db/*.sqlite3

--- a/rails-unicorn/.dockerignore.j2
+++ b/rails-unicorn/.dockerignore.j2
@@ -16,7 +16,6 @@ README.md
 .env.sample
 *.rbc
 capybara-*.html
-.rspec
 log
 tmp
 db/*.sqlite3


### PR DESCRIPTION
Problem:

A lot of projects use `hokusai test` to run their build on CI, and for
Ruby projects, the repository-level RSpec settings are described in the
.rspec file. As such, it makes sense to have CI (via `hokusai test`) run
RSpec with these settings.

Solution:

Remove .rspec from .dockerignore.j2 for rails-puma and rails-unicorn

Related:

Currently working on artsy/currents and ran into [test failures][0] only on
CI. Trying to get more information, we attempted to run the test suite
with `--format documentation`, but didn't get any different output!

[0]:
https://circleci.com/gh/artsy/currents/900?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

---

cc @yuki24 @joeyAghion 