### PR TITLE
Update templates based on most recent project experience

### DIFF
--- a/default/.dockerignore.j2
+++ b/default/.dockerignore.j2
@@ -17,4 +17,3 @@ env
 log
 *.log
 tmp
-

--- a/default/Dockerfile.j2
+++ b/default/Dockerfile.j2
@@ -12,4 +12,3 @@ EXPOSE 8080
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["nginx", "-g", "daemon off;"]
-

--- a/default/hokusai/build.yml.j2
+++ b/default/hokusai/build.yml.j2
@@ -4,4 +4,3 @@ services:
   {{ project_name }}:
     build:
       context: ../
-

--- a/default/hokusai/development.yml.j2
+++ b/default/hokusai/development.yml.j2
@@ -7,4 +7,3 @@ services:
       service: {{ project_name }}
     ports:
       - 8080:8080
-

--- a/default/hokusai/test.yml.j2
+++ b/default/hokusai/test.yml.j2
@@ -6,4 +6,3 @@ services:
     extends:
       file: build.yml
       service: {{ project_name }}
-

--- a/nodejs/hokusai/build.yml.j2
+++ b/nodejs/hokusai/build.yml.j2
@@ -4,4 +4,3 @@ services:
   {{ project_name }}:
     build:
       context: ../
-

--- a/nodejs/hokusai/development.yml.j2
+++ b/nodejs/hokusai/development.yml.j2
@@ -7,4 +7,3 @@ services:
       service: {{ project_name }}
     ports:
       - 3000:3000
-

--- a/nodejs/hokusai/test.yml.j2
+++ b/nodejs/hokusai/test.yml.j2
@@ -6,4 +6,3 @@ services:
     extends:
       file: build.yml
       service: {{ project_name }}
-

--- a/rails-puma/Dockerfile.j2
+++ b/rails-puma/Dockerfile.j2
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
-RUN apt-get update -qq && apt-get install -y nodejs mongodb-clients && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -qq && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN gem install bundler
 

--- a/rails-puma/Dockerfile.j2
+++ b/rails-puma/Dockerfile.j2
@@ -27,9 +27,8 @@ RUN bundle install -j4
 ADD . /app
 WORKDIR /app
 
-# Setup Rails shared folders for Puma / Nginx
+# Setup Rails shared folders for Puma
 RUN mkdir /shared
-RUN mkdir /shared/config
 RUN mkdir /shared/pids
 RUN mkdir /shared/sockets
 

--- a/rails-puma/hokusai/build.yml.j2
+++ b/rails-puma/hokusai/build.yml.j2
@@ -4,4 +4,3 @@ services:
   {{ project_name }}:
     build:
       context: ../
-

--- a/rails-puma/hokusai/development.yml.j2
+++ b/rails-puma/hokusai/development.yml.j2
@@ -10,4 +10,3 @@ services:
       - 3000:3000
     volumes:
       - ../:/app
-

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -21,10 +21,6 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
-            - name: PORT
-              value: "8080"
-            - name: RAILS_ENV
-              value: production
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: RAILS_LOG_TO_STDOUT

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -141,7 +141,7 @@ spec:
     - port: 443
       protocol: TCP
       name: https
-      targetPort: nginx-https
+      targetPort: nginx-http
   selector:
     app: {{ project_name }}
     layer: application

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -21,10 +21,6 @@ spec:
       containers:
         - name: {{ project_name }}-web
           env:
-            - name: PORT
-              value: "8080"
-            - name: RAILS_ENV
-              value: production
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: RAILS_LOG_TO_STDOUT

--- a/rails-puma/hokusai/test.yml.j2
+++ b/rails-puma/hokusai/test.yml.j2
@@ -7,4 +7,3 @@ services:
     extends:
       file: build.yml
       service: {{ project_name }}
-

--- a/rails-unicorn/hokusai/build.yml.j2
+++ b/rails-unicorn/hokusai/build.yml.j2
@@ -6,4 +6,3 @@ services:
       context: ../
       args:
         BUNDLE_GITHUB__COM: ${BUNDLE_GITHUB__COM}
-

--- a/rails-unicorn/hokusai/development.yml.j2
+++ b/rails-unicorn/hokusai/development.yml.j2
@@ -10,4 +10,3 @@ services:
       - 8080:8080
     volumes:
       - ../:/app
-

--- a/rails-unicorn/hokusai/test.yml.j2
+++ b/rails-unicorn/hokusai/test.yml.j2
@@ -7,4 +7,3 @@ services:
     extends:
       file: build.yml
       service: {{ project_name }}
-


### PR DESCRIPTION
As discussed... details are in the individual commits.

Q: These templates do _not_ include the `hokusai/config.yml` configuration file, right? I was thinking it might be helpful to include a `pre-deploy: 'rake db:migrate'` in that file for Rails-style projects.

Will follow up with a few more questions.
