### PR TITLE
Update staging.yml to use HTTP to origin, like production.yml

### DIFF
--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -141,7 +141,7 @@ spec:
     - port: 443
       protocol: TCP
       name: https
-      targetPort: nginx-https
+      targetPort: nginx-http
   selector:
     app: {{ project_name }}
     layer: application


### PR DESCRIPTION
Makes `staging.yml` consistent with `production.yml`.