### PR TITLE
Updated staging/production yml, to add PORT and some PUMA vars.

### DIFF
--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: {% raw %}{{ project_name }}{% endraw %}-web
           env:
+            - name: PORT
+              value: "8080"
+            - name: PUMA_WORKERS
+              value: "1"
+            - name: PUMA_THREAD_MIN
+              value: "5"
+            - name: PUMA_THREAD_MAX
+              value: "5"
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: RAILS_LOG_TO_STDOUT

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -35,6 +35,8 @@ spec:
               value: 'true'
             - name: PUMA_BIND
               value: 'tcp://0.0.0.0:8080'
+            - name: MALLOC_ARENA_MAX
+              value: "2"
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: {% raw %}{{ project_name }}{% endraw %}-web
           env:
+            - name: PORT
+              value: "8080"
+            - name: PUMA_WORKERS
+              value: "1"
+            - name: PUMA_THREAD_MIN
+              value: "5"
+            - name: PUMA_THREAD_MAX
+              value: "5"
             - name: RAILS_SERVE_STATIC_FILES
               value: 'true'
             - name: RAILS_LOG_TO_STDOUT

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -35,6 +35,8 @@ spec:
               value: 'true'
             - name: PUMA_BIND
               value: 'tcp://0.0.0.0:8080'
+            - name: MALLOC_ARENA_MAX
+              value: "2"
             - name: TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Motivated by a discussion in a separate PR: https://github.com/artsy/pulse/pull/652

In the conversation there we think that PORT should be included in staging/production.yml. So I would like to add it to the template. Also want to add the following:

PUMA_WORKERS
PUMA_THREAD_MIN
PUMA_THREAD_MAX
MALLOC_ARENA_MAX

These PUMA vars are referred to in puma.config. They very likely should be tuned per application, so it seems reasonable to make it explicit. Although, I am not sure what default values are good, except for MALLOC_ARENA_MAX=2 which we are quite sure from experimentation.

Speaking of MALLOC_ARENA_MAX, which benefits sidekiq most. But we do not template sidekiq. Should we add?