### PR TITLE
Revert "upgrade deployments to apps/v1"

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -110,7 +110,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 2

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -110,7 +110,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -116,7 +116,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 2

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -116,7 +116,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -128,7 +128,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 2

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}-web
@@ -128,7 +128,7 @@ metadata:
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: extensions/v1beta1
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1


### PR DESCRIPTION
This reverts commit e2ca76c299f437eace32d0c5271201d0a45223da.

Downgrade Deployment api versions from `apps/v1` to `extensions/v1beta1` as when applying via `kubectl` the API server downgrades the versions anyway and fails to populate deployment labels