### PR TITLE
Changes to cpu request. Add Node env var for max old heap size.

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -42,7 +42,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 300m
+              cpu: 200m
               memory: 256Mi
             limits:
               memory: 1Gi

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -42,7 +42,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
               memory: 512Mi

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -38,6 +38,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           envFrom:
             - configMapRef:
                 name: {% raw %}{{ project_name }}{% endraw %}-environment
@@ -48,7 +50,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 300m
+              cpu: 200m
               memory: 256Mi
             limits:
               memory: 1Gi

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -38,6 +38,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           envFrom:
             - configMapRef:
                 name: {% raw %}{{ project_name }}{% endraw %}-environment
@@ -48,7 +50,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
               memory: 512Mi

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -60,7 +60,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 300m
+              cpu: 200m
               memory: 256Mi
             limits:
               memory: 1Gi

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -60,7 +60,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
               memory: 512Mi


### PR DESCRIPTION
- Reduce staging cpu request to 100m.
- Reduce prod cpu request to 200m.
- Nodejs, add NODE_OPTIONS env var which specifies max_old_space_size to equal memory request. (as is the case for metaphysics)