### PR TITLE
Check for deploy blocks prior to releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Application developers can set up a project by specifying which target directory
 Bootstrap a Rails/Puma project:
 
 ```shell
-hokusai setup --template-remote git@github.com:artsy/artsy-hokusai-templates.git --template-dir rails-puma
+hokusai setup --template-remote git@github.com:artsy/artsy-hokusai-templates.git --template-dir rails-puma [--var horizon_project_id=99]
 ```
 
 ## Template directory structure

--- a/default/.circleci/config.yml.j2
+++ b/default/.circleci/config.yml.j2
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hokusai: artsy/hokusai@0.7.0
+  horizon: artsy/release@0.0.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -25,6 +26,11 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: {{ horizon_project_id|default("REPLACE_ME", true) }}
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -42,3 +48,5 @@ workflows:
 
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block

--- a/nodejs/.circleci/config.yml.j2
+++ b/nodejs/.circleci/config.yml.j2
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hokusai: artsy/hokusai@0.7
+  horizon: artsy/release@0.0.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -25,6 +26,11 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: {{ horizon_project_id|default("REPLACE_ME", true) }}
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -42,3 +48,5 @@ workflows:
 
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block

--- a/rails-puma/.circleci/config.yml.j2
+++ b/rails-puma/.circleci/config.yml.j2
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hokusai: artsy/hokusai@0.7
+  horizon: artsy/release@0.0.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -25,6 +26,11 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: {{ horizon_project_id|default("REPLACE_ME", true) }}
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -42,3 +48,5 @@ workflows:
 
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block


### PR DESCRIPTION
Along with updating the [deployment playbook](https://github.com/artsy/README/blob/master/playbooks/deployments.md#tools), we should ensure that projects have the appropriate safeguards in place from the start. This PR adds the `block` step from [Horizon's orb](https://github.com/artsy/orbs/blob/master/src/release/release.yml) to all templates' release workflow.

A new `horizon_project_id` var can be provided during set-up time, but if it's not then `REPLACE_ME` is substituted in the `.circleci/config.yml`. (The README says that "Users will get a warning if trying to render a template with a defined but unspecified variable" but it looks more like an error in my local experiments.)