### PR TITLE
fix: wrap cloudflareIPSourceRanges in raw tag

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -118,7 +118,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}.artsy.net

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -118,7 +118,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}-staging.artsy.net

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -126,7 +126,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}.artsy.net

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -126,7 +126,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}-staging.artsy.net

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -136,7 +136,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}.artsy.net

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -136,7 +136,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
 spec:
   rules:
     - host: {% raw %}{{ project_name }}{% endraw %}-staging.artsy.net


### PR DESCRIPTION
The config block `{{ cloudflareIpSourceRanges|join(',') }}` should be rendered as a string into staging / production Yaml templates so wrap it with a `raw` tag.  @alexpopa-artsy and I ran into a `UndefinedError: 'cloudflareIpSourceRanges' is undefined` error when running `hokusai setup`

We may want to change the extensions of these templates to `.yml.j2.j2` so we end up with `.yml.j2` files in the repo.  Will follow up with another PR about this.
