### PR TITLE
feat: use externalIngressAllowSourceIP var for external ingress allow ip.

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -118,7 +118,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -118,7 +118,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -126,7 +126,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -126,7 +126,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -136,7 +136,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -136,7 +136,7 @@ kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ cloudflareIpSourceRanges|join(',') }}{% endraw %}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{% raw %}{{ externalIngressAllowSourceIP|join(',') }}{% endraw %}"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1610644120020700

Added `externalIngressAllowSourceIP` var to `s3://artsy-citadel/k8s/hokusai-vars.yml`. The var contains Cloudflare and internal IP ranges.

Update template so that we use this var for external ingress `whitelist-source-range` annotation.

Left  `{% endraw %}` in place but note that it didn't work for `hokusai-sandbox`.