### PR TITLE
feat: add cronjob to templates, and misc.

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -137,7 +137,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -139,6 +139,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -56,10 +56,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -130,3 +126,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:production
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -42,7 +42,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
             limits:
               memory: 512Mi
@@ -87,7 +87,7 @@ spec:
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 70
 
 ---

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -137,7 +137,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -130,3 +130,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:staging
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -56,10 +56,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -139,6 +139,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -147,6 +147,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -145,7 +145,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -64,10 +64,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -138,3 +134,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:production
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -147,6 +147,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -50,7 +50,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
             limits:
               memory: 512Mi
@@ -64,10 +64,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -95,7 +91,7 @@ spec:
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 70
 
 ---
@@ -138,3 +134,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:staging
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -145,7 +145,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -157,6 +157,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -74,10 +74,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -148,3 +144,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:production
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -155,7 +155,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -157,6 +157,9 @@ spec:
     spec:
       backoffLimit: 0 # no retry if job fails.
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: {% raw %}{{ project_name }}{% endraw %}-cron-example

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -155,7 +155,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 0 # no retry if job fails.
+      backoffLimit: 0 # do not retry if pod fails.
       template:
         metadata:
           annotations:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -60,7 +60,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
             limits:
               memory: 512Mi
@@ -74,10 +74,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -105,7 +101,7 @@ spec:
     kind: Deployment
     name: {% raw %}{{ project_name }}{% endraw %}-web
   minReplicas: 1
-  maxReplicas: 3
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 70
 
 ---
@@ -148,3 +144,35 @@ spec:
             backend:
               serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
               servicePort: http
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+spec:
+  schedule: "11 11 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # no retry if job fails.
+      template:
+        spec:
+          containers:
+            - name: {% raw %}{{ project_name }}{% endraw %}-cron-example
+              image: {% raw %}{{ project_repo }}{% endraw %}:staging
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: {% raw %}{{ project_name }}{% endraw %}-environment
+              args: ["echo", "i am just an example"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background


### PR DESCRIPTION
In preparation for https://artsyproduct.atlassian.net/browse/PLATFORM-3175.

- Add cronjob to k8s spec template. Not every project has a cronjob, but many do, and there's a bunch of settings we'd like to lock down (`safe-to-evict`, `concurrencyPolicy`, `backoffLimit`, `nodeAffinity`).

- Remove `preStop` sleep. It was to ensure that the app container terminates after Nginx sidecar. Now that there's no sidecar, I don't see a reason for it.