### PR TITLE
feat: use name for service target port

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -101,7 +101,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -101,7 +101,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -109,7 +109,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -109,7 +109,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -119,7 +119,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -119,7 +119,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: {% raw %}{{ project_name }}{% endraw %}-http
   selector:
     app: {% raw %}{{ project_name }}{% endraw %}
     layer: application


### PR DESCRIPTION
Since in container spec we already give a name to its port, it seems good to have the service point to that name.