### PR TITLE
fix: put preStop hook back.

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -56,6 +56,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -56,6 +56,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -64,6 +64,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -64,6 +64,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -74,6 +74,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -74,6 +74,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
In https://github.com/artsy/artsy-hokusai-templates/pull/30, I thought that `preStop` hook of the app container is no longer required.

However, per discussion in https://github.com/artsy/gravity/pull/13917, the hook should still be required. Therefore, adding it back.