### PR TITLE
feat: match puma thread count default with rails db pool size

### DIFF
--- a/rails-puma/config/puma.config
+++ b/rails-puma/config/puma.config
@@ -5,7 +5,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 daemonize false
 pidfile  "/shared/pids/puma.pid"
 state_path "/shared/pids/puma.state"
-threads ENV.fetch("PUMA_THREAD_MIN") { 0 }.to_i, ENV.fetch("PUMA_THREAD_MAX") { 16 }.to_i
+threads ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i, ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 bind ENV.fetch("PUMA_BIND") { "tcp://0.0.0.0:3000" }
 activate_control_app "unix:///shared/sockets/pumactl.sock", { no_token: true }
 workers ENV.fetch("PUMA_WORKERS") { 1 }.to_i


### PR DESCRIPTION
Follow up on https://github.com/artsy/impulse/pull/740

Currently the [puma thread count default](https://github.com/artsy/artsy-hokusai-templates/blob/c4d9c82dccfdfd07e3b4d4f80ec0c514f2402355/rails-puma/config/puma.config#L8) (0 to 16) doesn't match the [default db pool size](https://github.com/rails/rails/blob/3dd0af563b5ebdccf1e3c1993f8a64f4ab5fce48/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt#L22) (5) of rails. This requires manual changes when setting up a new app; otherwise the app might suffer from insufficient db connection during high traffic.

This updates the default and uses the same `RAILS_MAX_THREADS` environment variable. Individual app can still tweak it if necessary.