### PR TITLE
Update templates to prefer main over master branch name

### DIFF
--- a/default/.circleci/config.yml.j2
+++ b/default/.circleci/config.yml.j2
@@ -11,11 +11,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -36,12 +36,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: {{ project_name }}
           requires:
             - push-staging-image

--- a/nodejs/.circleci/config.yml.j2
+++ b/nodejs/.circleci/config.yml.j2
@@ -11,11 +11,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -36,12 +36,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: {{ project_name }}
           requires:
             - push-staging-image

--- a/rails-puma/.circleci/config.yml.j2
+++ b/rails-puma/.circleci/config.yml.j2
@@ -11,11 +11,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -36,12 +36,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: {{ project_name }}
           requires:
             - push-staging-image


### PR DESCRIPTION
I set up a new project with our templates (https://github.com/artsy/power/pull/67), and discovered that [the build](https://app.circleci.com/pipelines/github/artsy/power/12/workflows/16f6f37e-7b26-4620-8bdc-d3ce22060b29) didn't do what I expected because the `.circleci/config.yml` template assumes the `master` branch name. (Later fixed in https://github.com/artsy/power/pull/69.)

This PR updates our templates to use `main` instead. Since they're almost always used by new repositories (which will default to `main`), I don't think we need to add any special handling for the `master` alternative.