### PR TITLE
feat: mention k8s 15 char limit on a port name.

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -38,6 +38,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:production
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -38,6 +38,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:staging
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -46,6 +46,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:production
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -46,6 +46,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:staging
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -56,6 +56,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:production
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -56,6 +56,7 @@ spec:
           image: {% raw %}{{ project_repo }}{% endraw %}:staging
           imagePullPolicy: Always
           ports:
+            # k8s limits a port name to 15 characters
             - name: {% raw %}{{ project_name }}{% endraw %}-http
               containerPort: 8080
           resources:


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3612

Encountered this restriction when re-configuring Acceleration's specs.

Make a comment about it in the templates so in the future it's apparent to folks setting up new projects.