### PR TITLE
feat: use latest version of artsy managed orbs, and track app version in k8s label

### DIFF
--- a/default/.circleci/config.yml.j2
+++ b/default/.circleci/config.yml.j2
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.7.0
-  horizon: artsy/release@0.0.1
+  # use latest version (volatile) for artsy managed orbs
+  hokusai: artsy/hokusai@volatile
+  horizon: artsy/release@volatile
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/nodejs/.circleci/config.yml.j2
+++ b/nodejs/.circleci/config.yml.j2
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.7
-  horizon: artsy/release@0.0.1
+  # use latest version (volatile) for artsy managed orbs
+  hokusai: artsy/hokusai@volatile
+  horizon: artsy/release@volatile
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -8,6 +8,7 @@ metadata:
     app: {% raw %}{{ project_name }}{% endraw %}
     component: web
     layer: application
+    app.kubernetes.io/version: production
 spec:
   strategy:
     rollingUpdate:
@@ -25,6 +26,7 @@ spec:
         app: {% raw %}{{ project_name }}{% endraw %}
         component: web
         layer: application
+        app.kubernetes.io/version: production
       name: {% raw %}{{ project_name }}{% endraw %}-web
     spec:
       containers:
@@ -38,6 +40,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
             - name: NODE_OPTIONS
               value: "--max_old_space_size=256"
           envFrom:

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -8,6 +8,7 @@ metadata:
     app: {% raw %}{{ project_name }}{% endraw %}
     component: web
     layer: application
+    app.kubernetes.io/version: staging
 spec:
   strategy:
     rollingUpdate:
@@ -25,6 +26,7 @@ spec:
         app: {% raw %}{{ project_name }}{% endraw %}
         component: web
         layer: application
+        app.kubernetes.io/version: staging
       name: {% raw %}{{ project_name }}{% endraw %}-web
     spec:
       containers:
@@ -38,6 +40,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
             - name: NODE_OPTIONS
               value: "--max_old_space_size=256"
           envFrom:

--- a/rails-puma/.circleci/config.yml.j2
+++ b/rails-puma/.circleci/config.yml.j2
@@ -1,8 +1,9 @@
 version: 2.1
 
 orbs:
-  hokusai: artsy/hokusai@0.7
-  horizon: artsy/release@0.0.1
+  # use latest version (volatile) for artsy managed orbs
+  hokusai: artsy/hokusai@volatile
+  horizon: artsy/release@volatile
 
 not_staging_or_release: &not_staging_or_release
   filters:

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -8,6 +8,7 @@ metadata:
     app: {% raw %}{{ project_name }}{% endraw %}
     component: web
     layer: application
+    app.kubernetes.io/version: production
 spec:
   strategy:
     rollingUpdate:
@@ -25,6 +26,7 @@ spec:
         app: {% raw %}{{ project_name }}{% endraw %}
         component: web
         layer: application
+        app.kubernetes.io/version: production
       name: {% raw %}{{ project_name }}{% endraw %}-web
     spec:
       containers:
@@ -50,6 +52,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
           envFrom:
             - configMapRef:
                 name: {% raw %}{{ project_name }}{% endraw %}-environment

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -8,6 +8,7 @@ metadata:
     app: {% raw %}{{ project_name }}{% endraw %}
     component: web
     layer: application
+    app.kubernetes.io/version: staging
 spec:
   strategy:
     rollingUpdate:
@@ -25,6 +26,7 @@ spec:
         app: {% raw %}{{ project_name }}{% endraw %}
         component: web
         layer: application
+        app.kubernetes.io/version: staging
       name: {% raw %}{{ project_name }}{% endraw %}-web
     spec:
       containers:
@@ -50,6 +52,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['app.kubernetes.io/version']
           envFrom:
             - configMapRef:
                 name: {% raw %}{{ project_name }}{% endraw %}-environment


### PR DESCRIPTION
Use latest versions of Artsy managed orbs
---
https://artsy.slack.com/archives/CA8SANW3W/p1649961862718249

We decided there's no need for projects to pin version of Artsy-managed CircleCI orbs.

Pinning the version requires us to update every project (through Renovate or manually) when there's a new orb release, which does not provide any additional safety, because we do not test on an official release, nor do we roll-out in batches of projects.

We test on a [canary (beta) testing](https://artsy.slack.com/archives/CA8SANW3W/p1649961862718249) version (prior to the release), which seems sufficiently safe.

Please note this is only about Artsy-managed orbs. Non-Artsy orbs (which the templates do not cover) should probably continue to be pin'd.

track app version
---
Follows: https://github.com/artsy/hokusai/pull/292
