### PR TITLE
fix: apk command

### DIFF
--- a/nodejs/Dockerfile.j2
+++ b/nodejs/Dockerfile.j2
@@ -10,7 +10,7 @@ RUN chown deploy:deploy /app
 WORKDIR /app
 
 # Install system dependencies
-RUN apk update && apk --no-cache --quiet add --update \
+RUN apk update && apk add --no-cache --quiet \
   build-base \
   dumb-init
 

--- a/rails-puma/Dockerfile.j2
+++ b/rails-puma/Dockerfile.j2
@@ -13,7 +13,7 @@ RUN mkdir /shared
 RUN chown deploy:deploy /shared
 
 # Set up OS libs
-RUN apk update && apk --no-cache --quiet add --update \
+RUN apk update && apk add --no-cache --quiet \
   build-base \
   dumb-init
 


### PR DESCRIPTION
https://github.com/artsy/gravity/pull/16843#discussion_r1332163206

- `--no-cache` and `--quiet` are options of `apk add` command (not `apk` itself), so it should be `apk add --no-cache --quiet`.
- there's no `--update` option for `apk` or `apk add`
  ```
  / # cat /etc/issue
  Welcome to Alpine Linux 3.18
  Kernel \r on an \m (\l)
  
  / # apk --help | grep update
    update     Update repository indexes
  / # apk add --help | grep update
    -U, --update-cache    Alias for '--cache-max-age 1'
  ```