### PR TITLE
chore: address kubernetes spec deprecations

### DIFF
--- a/default/hokusai/production.yml.j2
+++ b/default/hokusai/production.yml.j2
@@ -128,7 +128,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
@@ -143,8 +143,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1

--- a/default/hokusai/staging.yml.j2
+++ b/default/hokusai/staging.yml.j2
@@ -127,7 +127,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
@@ -142,8 +142,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1

--- a/nodejs/hokusai/production.yml.j2
+++ b/nodejs/hokusai/production.yml.j2
@@ -142,7 +142,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
@@ -157,8 +157,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1

--- a/nodejs/hokusai/staging.yml.j2
+++ b/nodejs/hokusai/staging.yml.j2
@@ -142,7 +142,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
@@ -157,8 +157,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1

--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -256,7 +256,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}
@@ -271,8 +271,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -271,8 +271,10 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: {% raw %}{{ project_name }}{% endraw %}-web-internal
-              servicePort: http
+              service:
+                name: {% raw %}{{ project_name }}{% endraw %}-web-internal
+                port:
+                  name: http
 
 ---
 apiVersion: batch/v1beta1


### PR DESCRIPTION
Similar to https://github.com/artsy/opstools/pull/58 and its many follow-ups. This project's specs are in subdirectories so didn't match the general script. Though, now that I think about it, the script can probably be improved to match `**/hokusai/*.yml*` instead...