### PR TITLE
fix: one more deprecation for kubernetes spec

### DIFF
--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -256,7 +256,7 @@ spec:
   type: ClusterIP
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {% raw %}{{ project_name }}{% endraw %}


### PR DESCRIPTION
Self-assigning this deprecation fix leftover from https://github.com/artsy/artsy-hokusai-templates/pull/42.