### PR TITLE
fix: exec probes without timeout setting

### DIFF
--- a/rails-puma/hokusai/production.yml.j2
+++ b/rails-puma/hokusai/production.yml.j2
@@ -183,6 +183,7 @@ spec:
                 - sidekiq
             initialDelaySeconds: 30
             periodSeconds: 30
+            timeoutSeconds: 3
           resources:
             requests:
               cpu: 100m

--- a/rails-puma/hokusai/staging.yml.j2
+++ b/rails-puma/hokusai/staging.yml.j2
@@ -183,6 +183,7 @@ spec:
                 - sidekiq
             initialDelaySeconds: 30
             periodSeconds: 30
+            timeoutSeconds: 3
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Resolves https://artsyproduct.atlassian.net/browse/PHIRE-338

Updating template after [Gravity](https://github.com/artsy/gravity/pull/16956) and other projects.